### PR TITLE
Use the Count when converting a MarshaledArray to a ReadOnlySpan

### DIFF
--- a/sources/LLVMSharp.Interop/Internals/MarshaledArray`1.cs
+++ b/sources/LLVMSharp.Interop/Internals/MarshaledArray`1.cs
@@ -32,7 +32,7 @@ namespace LLVMSharp.Interop
 
         public static implicit operator ReadOnlySpan<U>(in MarshaledArray<T, U> value)
         {
-            return value.Values;
+            return new ReadOnlySpan<U>(value.Values, 0, value.Count);
         }
 
         public void Dispose()


### PR DESCRIPTION
I encountered an error when using `BuildGEP` saying there were some null elements being passed in. 

The `ArrayPool` can sometimes return a larger array than what was requested, so was causing extra null elements to be passed into the function.

This PR should resolve the issue by setting the expected length of the array into the `ReadOnlySpan` which will act to limit the length.