### PR TITLE
Add HelloWorld sample of LLVM14

### DIFF
--- a/LLVMSharp.sln
+++ b/LLVMSharp.sln
@@ -133,6 +133,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libLLVM.runtime.osx-arm64",
 		packages\libLLVM\libLLVM.runtime.osx-arm64\libLLVM.runtime.osx-arm64.nuspec = packages\libLLVM\libLLVM.runtime.osx-arm64\libLLVM.runtime.osx-arm64.nuspec
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{82CA612E-DAD7-456C-B7FC-6EC4F578245A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HelloWorld", "HelloWorld", "{E4DCDEBA-2768-49D5-9BF9-651F6D1CA390}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorld_LLVM14", "samples\HelloWorld\HelloWorld_LLVM14\HelloWorld_LLVM14.csproj", "{60E0FFE6-7FC2-43EB-B3E1-339A207CC7E2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +157,10 @@ Global
 		{CEA0F0C9-DF25-446B-8F55-FB629BD1D3E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CEA0F0C9-DF25-446B-8F55-FB629BD1D3E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CEA0F0C9-DF25-446B-8F55-FB629BD1D3E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60E0FFE6-7FC2-43EB-B3E1-339A207CC7E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60E0FFE6-7FC2-43EB-B3E1-339A207CC7E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60E0FFE6-7FC2-43EB-B3E1-339A207CC7E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60E0FFE6-7FC2-43EB-B3E1-339A207CC7E2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -174,6 +184,8 @@ Global
 		{4F526018-55AE-41FF-BF01-21F60EB95CBC} = {9D46FF1C-E09F-4063-A97D-C09F26310B67}
 		{C8508256-2EC1-4C88-B61D-AFB86569FBCD} = {9D46FF1C-E09F-4063-A97D-C09F26310B67}
 		{3870145D-F6DC-4082-A3F5-2316D49ADD43} = {9D46FF1C-E09F-4063-A97D-C09F26310B67}
+		{E4DCDEBA-2768-49D5-9BF9-651F6D1CA390} = {82CA612E-DAD7-456C-B7FC-6EC4F578245A}
+		{60E0FFE6-7FC2-43EB-B3E1-339A207CC7E2} = {E4DCDEBA-2768-49D5-9BF9-651F6D1CA390}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {75550D8C-A492-4ED3-8387-206830F8B21E}

--- a/samples/HelloWorld/HelloWorld_LLVM14/HelloWorld_LLVM14.csproj
+++ b/samples/HelloWorld/HelloWorld_LLVM14/HelloWorld_LLVM14.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="libLLVM" Version="14.0.0" />
+    <PackageReference Include="LLVMSharp" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/samples/HelloWorld/HelloWorld_LLVM14/Program.cs
+++ b/samples/HelloWorld/HelloWorld_LLVM14/Program.cs
@@ -1,0 +1,127 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using LLVMSharp;
+
+// Create extern function //
+LLVMValueRef CreateExtern(
+    LLVMModuleRef module,
+    string name,
+    LLVMTypeRef returnType,
+    LLVMTypeRef[] parameters,
+    bool isVarArg = false
+)
+{
+    var funcTy = LLVM.FunctionType(returnType, parameters, isVarArg);
+    var func = LLVM.AddFunction(module, name, funcTy);
+    func.SetLinkage(LLVMLinkage.LLVMExternalLinkage);
+    return func;
+}
+
+// Declare puts() //
+LLVMValueRef DeclarePuts(LLVMModuleRef module)
+{
+    var returnType = LLVM.Int32Type();
+    var parameters = new LLVMTypeRef[] { LLVM.PointerType(LLVM.Int8Type(), 0) };
+    return CreateExtern(module, "puts", returnType, parameters);
+}
+
+// Create function with entry basic block //
+// return function and builder of entry basic block
+(LLVMValueRef, LLVMBuilderRef) CreateFunction(
+    LLVMModuleRef module,
+    string name,
+    LLVMTypeRef returnType,
+    LLVMTypeRef[] parameters,
+    bool isVarArgs = false
+)
+{
+    var funcType = LLVM.FunctionType(returnType, parameters, isVarArgs);
+    var func = LLVM.AddFunction(module, name, funcType);
+    var entry = LLVM.AppendBasicBlock(func, "entry");
+    var builder = LLVM.CreateBuilder();
+    LLVM.PositionBuilderAtEnd(builder, entry);
+
+    return (func, builder);
+}
+
+// Create main function //
+(LLVMValueRef, LLVMBuilderRef) CreateMain(LLVMModuleRef module)
+{
+    return CreateFunction(module, "main", LLVM.Int32Type(), Array.Empty<LLVMTypeRef>());
+}
+
+// Run module in JIT Compiler //
+// Sometimes crashes with "LLVM ERROR: IMAGE_REL_AMD64_ADDR32NB relocation requires an ordered section layout"
+void RunMain(LLVMModuleRef module)
+{
+    LLVM.LinkInMCJIT();
+    LLVM.InitializeX86TargetMC();
+
+    LLVM.InitializeX86Target();
+    LLVM.InitializeX86TargetInfo();
+    LLVM.InitializeX86AsmParser();
+    LLVM.InitializeX86AsmPrinter();
+
+    _ = LLVM.CreateExecutionEngineForModule(out var engine, module, out var _);
+    var main = LLVM.GetNamedFunction(module, "main");
+    _ = LLVM.RunFunction(engine, main, Array.Empty<LLVMGenericValueRef>());
+}
+
+// Context and Module //
+var context = LLVM.ContextCreate();
+var module = LLVM.ModuleCreateWithNameInContext("Hello World", context);
+
+// Declare puts() and main()
+var funcPuts = DeclarePuts(module);
+var (_, builder_main) = CreateMain(module);
+
+// Create global string //
+var constStr = LLVM.BuildGlobalStringPtr(builder_main, "Hello World!", "");
+var parameters = new LLVMValueRef[] { constStr };
+var constInt0 = LLVM.ConstInt(LLVM.Int32Type(), 0, true);
+
+// Following is another way to create a global const string 
+// LLVM.BuildGlobalStringPtr needs a builder with a function
+// This way haven't this limit, but longer and unreadable
+
+//var helloWorldString = "Hello World!";
+//var globVar = LLVM.AddGlobal(module, LLVM.ArrayType(LLVM.Int8Type(), (uint)helloWorldString.Length + 1), "");
+//LLVM.SetInitializer(globVar, LLVM.ConstString(helloWorldString, (uint)helloWorldString.Length, false));
+//var gep = LLVM.ConstGEP(globVar, new LLVMValueRef[] { constInt0, constInt0 });
+//var parameters = new LLVMValueRef[] { gep };
+
+// Create function call and return instruction //
+_ = LLVM.BuildCall(builder_main, funcPuts, parameters, "");
+_ = LLVM.BuildRet(builder_main, constInt0);
+
+// Output LLVM IR //
+Console.WriteLine("[Output of LLVM IR]:\n");
+LLVM.DumpModule(module);
+Console.WriteLine();
+
+// Run in JIT Compiler //
+Console.WriteLine("[Output of JIT Compiler]:\n");
+RunMain(module);
+
+// Expect console output //
+/*
+[Output of LLVM IR]:
+
+; ModuleID = 'Hello World'
+source_filename = "Hello World"
+
+@0 = private unnamed_addr constant[13 x i8] c "Hello World!\00", align 1
+
+declare i32 @puts(i8* %0)
+
+define i32 @main() {
+    entry:
+  % 0 = call i32 @puts(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @0, i32 0, i32 0))
+  ret i32 0
+}
+
+[Output of JIT Compiler]:
+
+Hello World!
+*/
+


### PR DESCRIPTION
HelloWorld sample of LLVM14

I'm not sure if the running JIT compiler part is correct (`RunMain()`).

This sample will output:

```ll
[Output of LLVM IR]:

; ModuleID = 'Hello World'
source_filename = "Hello World"

@0 = private unnamed_addr constant [13 x i8] c"Hello World!\00", align 1

declare i32 @puts(i8* %0)

define i32 @main() {
entry:
  %0 = call i32 @puts(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @0, i32 0, i32 0))
  ret i32 0
}

[Output of JIT Compiler]:

Hello World!
```